### PR TITLE
【14】認証テーブルシード機能を実装する

### DIFF
--- a/docs/auth-seed.md
+++ b/docs/auth-seed.md
@@ -1,0 +1,62 @@
+# ローカル環境向け Supabase Auth シード手順
+
+テストユーザーでの検証を素早く行うため、ローカル環境専用のシードスクリプトを用意しています。  
+このスクリプトは Supabase Auth のユーザーテーブルを一度空にし、`seed-data/auth-users.json` の内容で再作成します。
+
+> **注意:** 本番や共有環境では絶対に実行しないでください。`NODE_ENV !== 'development'` の場合はスクリプトが即終了するよう防御しています。
+
+---
+
+## 1. 事前準備
+
+1. **Supabase Service Role Key の取得**  
+   Supabase Dashboard → **Project Settings** → **API** → `Service Role Key` を「Reveal」してコピーします。
+2. **環境変数の設定（ローカルのみ）**  
+   `.env`（またはローカル用 env ファイル）に以下を設定します。  
+   ```
+   NEXT_PUBLIC_SUPABASE_URL=...        # プロジェクトURL
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=...   # anonキー
+   SUPABASE_SERVICE_ROLE_KEY=...       # 取得したService Role
+   ```
+   - `SUPABASE_SERVICE_ROLE_KEY` は強力な権限を持つため、Gitにコミットしたり公開しないでください。
+3. **シードデータの編集（任意）**  
+   `seed-data/auth-users.json` に投入したいユーザーをJSON配列で定義します。
+   ```json
+   [
+     {
+       "email": "dev-user1@example.com",
+       "password": "Password123",
+       "user_metadata": { "role": "tester" }
+     },
+     {
+       "email": "dev-user2@example.com",
+       "password": "Password456",
+       "user_metadata": { "role": "viewer" }
+     }
+   ]
+   ```
+
+---
+
+## 2. 実行方法
+
+```bash
+npm run seed:auth
+```
+
+- 内部で `NODE_ENV=development tsx scripts/seed-auth.ts` を実行します。
+- 既存ユーザーを1件ずつ削除した後、JSONファイルの内容を作成します。
+- 処理ログがターミナルに逐次出力されます。
+
+---
+
+## 3. 動作確認手順
+
+1. `npm run seed:auth` を実行してユーザーを再作成  
+2. `npm run dev` でローカルサーバーを起動  
+3. `seed-data/auth-users.json` に記載した各ユーザーでログインを確認  
+   - 例: `dev-user1@example.com / Password123`
+   - 例: `dev-user2@example.com / Password456`
+
+ユーザーを追加・変更したい場合は JSON を編集して、再度 `npm run seed:auth` を実行してください。
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "cross-env": "^7.0.3",
         "eslint": "^9",
         "eslint-config-next": "16.0.1",
         "tailwindcss": "^4",
@@ -3207,6 +3208,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "seed:auth": "cross-env NODE_ENV=development tsx scripts/seed-auth.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.7.0",
@@ -23,6 +24,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
+    "cross-env": "^7.0.3",
     "tailwindcss": "^4",
     "tsx": "^4.20.6",
     "typescript": "^5"

--- a/scripts/seed-auth.ts
+++ b/scripts/seed-auth.ts
@@ -1,0 +1,165 @@
+import "dotenv/config";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminClient } from "../src/lib/supabase/admin";
+
+type SeedUser = {
+  email: string;
+  password: string;
+  user_metadata?: Record<string, unknown>;
+};
+
+const USERS_PER_PAGE = 1000;
+
+function assertDevelopmentEnvironment() {
+  if (process.env.NODE_ENV !== "development") {
+    console.error(
+      "This script can only be executed when NODE_ENV is set to 'development'."
+    );
+    process.exit(1);
+  }
+}
+
+function resolveSeedFilePath(): string {
+  return path.resolve(process.cwd(), "seed-data", "auth-users.json");
+}
+
+async function loadSeedUsers(filePath: string): Promise<SeedUser[]> {
+  const fileContent = await readFile(filePath, "utf-8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fileContent);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse seed data file (${filePath}). Ensure it contains valid JSON.`,
+      { cause: error }
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("Seed data must be an array of user objects.");
+  }
+
+  return parsed.map((entry, index) => {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as SeedUser).email !== "string" ||
+      typeof (entry as SeedUser).password !== "string"
+    ) {
+      throw new Error(
+        `Invalid seed data at index ${index}. Each entry must include 'email' and 'password'.`
+      );
+    }
+
+    return {
+      email: (entry as SeedUser).email,
+      password: (entry as SeedUser).password,
+      user_metadata: (entry as SeedUser).user_metadata,
+    };
+  });
+}
+
+async function deleteAllUsers(client: SupabaseClient) {
+  console.log("Deleting existing auth users...");
+
+  let page = 1;
+  let deletedCount = 0;
+
+  while (true) {
+    const { data, error } = await client.auth.admin.listUsers({
+      page,
+      perPage: USERS_PER_PAGE,
+    });
+
+    if (error) {
+      throw new Error("Failed to list users via Supabase Admin API.", {
+        cause: error,
+      });
+    }
+
+    const users = data?.users ?? [];
+
+    if (users.length === 0) {
+      break;
+    }
+
+    for (const user of users) {
+      const { error: deleteError } = await client.auth.admin.deleteUser(
+        user.id
+      );
+
+      if (deleteError) {
+        throw new Error(
+          `Failed to delete user (id: ${user.id}, email: ${user.email}).`,
+          { cause: deleteError }
+        );
+      }
+
+      deletedCount += 1;
+      console.log(` - Deleted ${user.email ?? user.id}`);
+    }
+
+    if (users.length < USERS_PER_PAGE) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  console.log(`Deleted ${deletedCount} user(s).`);
+}
+
+async function insertSeedUsers(
+  client: SupabaseClient,
+  users: SeedUser[]
+): Promise<void> {
+  console.log("Creating seed users...");
+
+  for (const user of users) {
+    const { error } = await client.auth.admin.createUser({
+      email: user.email,
+      password: user.password,
+      email_confirm: true,
+      user_metadata: user.user_metadata,
+    });
+
+    if (error) {
+      throw new Error(`Failed to create user (${user.email}).`, {
+        cause: error,
+      });
+    }
+
+    console.log(` - Created ${user.email}`);
+  }
+
+  console.log(`Created ${users.length} user(s).`);
+}
+
+async function main() {
+  assertDevelopmentEnvironment();
+
+  const seedFilePath = resolveSeedFilePath();
+  const users = await loadSeedUsers(seedFilePath);
+
+  if (users.length === 0) {
+    console.warn("No users defined in the seed file. Skipping creation step.");
+    return;
+  }
+
+  const client = createAdminClient();
+
+  await deleteAllUsers(client);
+  await insertSeedUsers(client, users);
+
+  console.log("✅ Auth tables have been re-seeded.");
+}
+
+main().catch((error) => {
+  console.error("❌ Seeding failed.");
+  console.error(error);
+  process.exit(1);
+});
+

--- a/seed-data/auth-users.json
+++ b/seed-data/auth-users.json
@@ -1,0 +1,16 @@
+[
+  {
+    "email": "dev-user1@example.com",
+    "password": "Password123",
+    "user_metadata": {
+      "role": "tester"
+    }
+  },
+  {
+    "email": "dev-user2@example.com",
+    "password": "Password456",
+    "user_metadata": {
+      "role": "viewer"
+    }
+  }
+]

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,29 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * SupabaseのAdmin APIにアクセスするためのクライアントを生成する。
+ * Service Role Keyはローカル環境でのみ使用すること。
+ */
+export function createAdminClient(): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL is not set. Please configure it in your environment."
+    );
+  }
+
+  if (!serviceRoleKey) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY is not set. Please configure it in your environment (local only)."
+    );
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+    },
+  });
+}
+


### PR DESCRIPTION
Notionタスク：認証テーブルシード機能を実装する

https://www.notion.so/2ad829eddd4881cfa2f4fa73b344c346

ローカル環境でSupabase認証テーブルをリセットし、テストユーザーを投入する機能を追加しました。